### PR TITLE
Correct the generic type of selectDom

### DIFF
--- a/src/select-dom.ts
+++ b/src/select-dom.ts
@@ -1,23 +1,23 @@
-export function selectDom<T extends Element>(container: T, attrName: string = 'data-automation-id'): (...selectors: string[]) => T | null {
+export function selectDom(container: Element, attrName: string = 'data-automation-id') {
 
-    function select(parentElement: T, ...selectors: string[]): T | null {
+    function select<T extends Element>(parentElement: Element, ...selectors: string[]): T | null {
         const [selector, ...rest] = selectors;
-        const elementList = parentElement.querySelectorAll(`[${attrName}~="${selector}"]`) as NodeListOf<T>;
-        if(elementList.length === 0) {
+        const elementList = parentElement.querySelectorAll(`[${attrName}~="${selector}"]`);
+        if (elementList.length === 0) {
             return null;
-        } else if(elementList.length === 1) {
+        } else if (elementList.length === 1) {
             const element = elementList[0];
-            if(rest.length>0) {
-                return select(element, ...rest);
+            if (rest.length > 0) {
+                return select<T>(element, ...rest);
             } else {
-                return element;
+                return element as T;
             }
         } else {
             throw new Error(`Selector "${selector}" ambiguous (${elementList.length} matches)`);
         }
     }
 
-    return function (...selectors: string[]): T | null {
-        return select(container, ...selectors);
+    return function <T extends Element>(...selectors: string[]) {
+        return select<T>(container, ...selectors);
     }
 }


### PR DESCRIPTION
The container is always an Element (i.e. you could try to select a path inside an svg).
The generic type should be provided to the returned select function (and not selectDom itself). This allows the user to specify a different type on every select, as it should.